### PR TITLE
Fix/integrations without email access

### DIFF
--- a/src/models/text/tests.rs
+++ b/src/models/text/tests.rs
@@ -66,7 +66,7 @@ fn rich_text_mention_user_person() {
             ),
           },
           person: Person {
-            email: "john.doe@gmail.com".to_string()
+            email: Some("john.doe@gmail.com".to_string())
           },
         }
       },

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -10,12 +10,12 @@ pub struct UserCommon {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Person {
-    pub email: String,
+    pub email: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Bot {
-    pub email: String,
+    pub email: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Fixes [https://github.com/jakeswenson/notion/issues/43](https://github.com/jakeswenson/notion/issues/43) by making the email field on users optional. 
This allows the usage with integrations that don't have full user access. 

However, this does not yet address the issue with full anonymous or deleted users who don't have a `type` property.