### PR TITLE
Improve/property access

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -13,7 +13,7 @@ use block::FileOrEmojiObject;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::ids::{AsIdentifier, DatabaseId, PageId};
+use crate::ids::{AsIdentifier, DatabaseId, PageId, PropertyId};
 use crate::models::block::{Block, CreateBlock};
 use crate::models::error::ErrorResponse;
 use crate::models::paging::PagingCursor;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -163,6 +163,20 @@ impl Properties {
             _ => None,
         })
     }
+
+    pub fn get_by_name(
+        &self,
+        name: &str,
+    ) -> Option<&PropertyValue> {
+        self.properties.get(name)
+    }
+
+    pub fn get_by_id(
+        &self,
+        id: &PropertyId,
+    ) -> Option<&PropertyValue> {
+        self.properties.values().find(|p| p.id() == id)
+    }
 }
 
 #[derive(Serialize, Debug, Eq, PartialEq)]

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 use crate::models::text::RichText;
 use crate::models::users::User;
 
@@ -495,6 +497,372 @@ impl PropertyValue {
             PropertyValue::Button { id } => id,
         }
     }
+
+    /// Allows for easy access to the property value.
+    ///
+    /// This is useful if you know the type of the property you want to access and don't need match statements
+    ///
+    /// ```rust,ignore
+    /// let title = property.expect_value::<Vec<RichText>>().unwrap();
+    /// ```
+    /// This will fail if the actual property type is not compatible with the expected value type.
+    ///
+    /// See the following implementations of `FromPropertyValue` for supported types:
+    /// - [`Vec<RichText>`](PropertyValue::from_property_value::<Vec<RichText>>) for Title, Text
+    /// - [`Option<Number>`](PropertyValue::from_property_value::<Option<Number>>) for Number
+    /// - [`Option<SelectedValue>`](PropertyValue::from_property_value::<Option<SelectedValue>>) for Select, Status, MultiSelect
+    /// - [`Option<Vec<SelectedValue>>`](PropertyValue::from_property_value::<Option<Vec<SelectedValue>>>) for MultiSelect
+    /// - [`Option<DateValue>`](PropertyValue::from_property_value::<Option<DateValue>>) for Date
+    /// - [`Option<Vec<RelationValue>>`](PropertyValue::from_property_value::<Option<Vec<RelationValue>>>) for Relation
+    /// - [`Option<Vec<FileReference>>`](PropertyValue::from_property_value::<Option<Vec<FileReference>>>) for Files
+    /// - [`bool`](PropertyValue::from_property_value::<bool>) for Checkbox
+    /// - [`Option<String>`](PropertyValue::from_property_value::<Option<String>>) for Url, Email, PhoneNumber
+    /// - [`DateTime<Utc>`](PropertyValue::from_property_value::<DateTime<Utc>>) for CreatedTime, LastEditedTime
+    /// - [`User`](PropertyValue::from_property_value::<User>) for CreatedBy, LastEditedBy
+    ///
+    /// You can also create your own implementation of `FromPropertyValue` for custom types. This is useful if you
+    /// need to convert the property value to a specific type in your project.
+    ///
+    /// For example if you want to access text property values always as a `String` without formatting you can do the following:
+    ///
+    /// ```rust
+    /// use rusticnotion::models::properties::{FromPropertyValue, PropertyValue, WrongPropertyTypeError}
+    ///
+    /// // We can use the new type pattern to create a custom type that implements FromPropertyValue
+    /// // This allows us easy access to property value in our desired type
+    /// struct TextValue(String);
+    /// impl FromPropertyValue for TextValue {
+    ///     fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+    ///         match value {
+    ///             PropertyValue::Text { rich_text, .. } => {
+    ///                 let combined_text = rich_text
+    ///                     .iter()
+    ///                     .map(|rt| rt.plain_text().to_string())
+    ///                     .collect::<Vec<String>>()
+    ///                     .join("");
+    ///                 Ok(TextValue(combined_text))
+    ///             }
+    ///             _ => Err(WrongPropertyTypeError {
+    ///                 expected: vec!["Text".to_string()],
+    ///                 actual: value.type_name(),
+    ///             }),
+    ///         }
+    ///     }
+    /// }
+    /// assert_eq!(
+    ///     page.properties
+    ///         .get_by_name("Text")
+    ///         .unwrap()
+    ///         .expect_value::<TextValue>()
+    ///         .unwrap()
+    ///         .0,
+    ///     "hello world".to_string()
+    /// );
+    /// ```
+    pub fn expect_value<T: FromPropertyValue>(&self) -> Result<T, WrongPropertyTypeError> {
+        T::from_property_value(self.clone())
+    }
+
+    /// Allows for easy access to the title property value.
+    /// This is a shortcut for `expect_value::<Vec<RichText>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a title, even if `Vec<RichText>` is implemented for the property.
+    pub fn expect_title(&self) -> Result<Vec<RichText>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Title { .. } => self.expect_value::<Vec<RichText>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Title".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the text property value.
+    /// This is a shortcut for `expect_value::<Vec<RichText>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a text, even if `Vec<RichText>` is implemented for the property.
+    pub fn expect_text(&self) -> Result<Vec<RichText>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Text { .. } => self.expect_value::<Vec<RichText>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Text".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the number property value.
+    /// This is a shortcut for `expect_value::<Number>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a number, even if `Option<Number>` is implemented for the property.
+    pub fn expect_number(&self) -> Result<Option<Number>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Number { .. } => self.expect_value::<Option<Number>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Number".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the select property value.
+    /// This is a shortcut for `expect_value::<Option<SelectedValue>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a select, even if `Option<SelectedValue>` is implemented for the property.
+    pub fn expect_select(&self) -> Result<Option<SelectedValue>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Select { .. } => self.expect_value::<Option<SelectedValue>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Select".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the status property value.
+    /// This is a shortcut for `expect_value::<Option<SelectedValue>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a status, even if `Option<SelectedValue>` is implemented for the property.
+    pub fn expect_status(&self) -> Result<Option<SelectedValue>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Status { .. } => self.expect_value::<Option<SelectedValue>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Status".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the multi-select property value.
+    /// This is a shortcut for `expect_value::<Vec<SelectedValue>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a multi-select, even if `Option<Vec<SelectedValue>>` is implemented for the property.
+    pub fn expect_multi_select(
+        &self
+    ) -> Result<Option<Vec<SelectedValue>>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::MultiSelect { .. } => self.expect_value::<Option<Vec<SelectedValue>>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["MultiSelect".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the date property value.
+    /// This is a shortcut for `expect_value::<Option<DateValue>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a date, even if `Option<DateValue>` is implemented for the property.
+    pub fn expect_date(&self) -> Result<Option<DateValue>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Date { .. } => self.expect_value::<Option<DateValue>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Date".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the people property value.
+    /// This is a shortcut for `expect_value::<Vec<User>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a people, even if `Option<Vec<User>>` is implemented for the property.
+    pub fn expect_people(&self) -> Result<Option<Vec<User>>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::People { .. } => self.expect_value::<Option<Vec<User>>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["People".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the files property value.
+    /// This is a shortcut for `expect_value::<Option<Vec<FileReference>>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a files, even if `Option<Vec<FileReference>>` is implemented for the property.
+    pub fn expect_files(&self) -> Result<Option<Vec<FileReference>>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Files { .. } => self.expect_value::<Option<Vec<FileReference>>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Files".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the checkbox property value.
+    /// This is a shortcut for `expect_value::<bool>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a checkbox, even if `bool` is implemented for the property.
+    pub fn expect_checkbox(&self) -> Result<bool, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Checkbox { .. } => self.expect_value::<bool>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Checkbox".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the url property value.
+    /// This is a shortcut for `expect_value::<Option<String>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a url, even if `Option<String>` is implemented for the property.
+    pub fn expect_url(&self) -> Result<Option<String>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Url { .. } => self.expect_value::<Option<String>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Url".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the email property value.
+    /// This is a shortcut for `expect_value::<Option<String>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not an email, even if `Option<String>` is implemented for the property.
+    pub fn expect_email(&self) -> Result<Option<String>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Email { .. } => self.expect_value::<Option<String>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Email".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the phone number property value.
+    /// This is a shortcut for `expect_value::<Option<String>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a phone number, even if `Option<String>` is implemented for the property.
+    pub fn expect_phone_number(&self) -> Result<Option<String>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::PhoneNumber { .. } => self.expect_value::<Option<String>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["PhoneNumber".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the formula property value.
+    /// This is a shortcut for `expect_value::<FormulaResultValue>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a formula, even if `FormulaResultValue` is implemented for the property.
+    pub fn expect_formula(&self) -> Result<FormulaResultValue, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Formula { .. } => self.expect_value::<FormulaResultValue>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Formula".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the relation property value.
+    /// This is a shortcut for `expect_value::<Option<Vec<RelationValue>>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a relation, even if `Option<Vec<RelationValue>>` is implemented for the property.
+    pub fn expect_relation(&self) -> Result<Option<Vec<RelationValue>>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Relation { .. } => self.expect_value::<Option<Vec<RelationValue>>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Relation".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the rollup property value.
+    /// This is a shortcut for `expect_value::<Option<RollupValue>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a rollup, even if `Option<RollupValue>` is implemented for the property.
+    pub fn expect_rollup(&self) -> Result<Option<RollupValue>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Rollup { .. } => self.expect_value::<Option<RollupValue>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Rollup".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the created time property value.
+    /// This is a shortcut for `expect_value::<DateTime<Utc>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a created time, even if `DateTime<Utc>` is implemented for the property.
+    pub fn expect_created_time(&self) -> Result<DateTime<Utc>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::CreatedTime { .. } => self.expect_value::<DateTime<Utc>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["CreatedTime".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the created by property value.
+    /// This is a shortcut for `expect_value::<User>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a created by, even if `User` is implemented for the property.
+    pub fn expect_created_by(&self) -> Result<User, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::CreatedBy { .. } => self.expect_value::<User>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["CreatedBy".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the last edited time property value.
+    /// This is a shortcut for `expect_value::<DateTime<Utc>>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a last edited time, even if `DateTime<Utc>` is implemented for the property.
+    pub fn expect_last_edited_time(&self) -> Result<DateTime<Utc>, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::LastEditedTime { .. } => self.expect_value::<DateTime<Utc>>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["LastEditedTime".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the last edited by property value.
+    /// This is a shortcut for `expect_value::<User>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a last edited by, even if `User` is implemented for the property.
+    pub fn expect_last_edited_by(&self) -> Result<User, WrongPropertyTypeError> {
+        match self {
+            PropertyValue::LastEditedBy { .. } => self.expect_value::<User>(),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["LastEditedBy".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    /// Allows for easy access to the button property value.
+    /// This is a shortcut for `expect_value::<()>()` which is more explicit about the expected property type.
+    /// This will also return an error if the property is not a button, even if `()` is implemented for the property.
+    pub fn expect_button(&self) -> Result<(), WrongPropertyTypeError> {
+        match self {
+            PropertyValue::Button { .. } => Ok(()),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Button".to_string()],
+                actual: self.type_name(),
+            }),
+        }
+    }
+
+    pub fn type_name(&self) -> String {
+        match self {
+            PropertyValue::Title { .. } => "Title".to_string(),
+            PropertyValue::Text { .. } => "Text".to_string(),
+            PropertyValue::Number { .. } => "Number".to_string(),
+            PropertyValue::Select { .. } => "Select".to_string(),
+            PropertyValue::Status { .. } => "Status".to_string(),
+            PropertyValue::MultiSelect { .. } => "MultiSelect".to_string(),
+            PropertyValue::Date { .. } => "Date".to_string(),
+            PropertyValue::People { .. } => "People".to_string(),
+            PropertyValue::Files { .. } => "Files".to_string(),
+            PropertyValue::Checkbox { .. } => "Checkbox".to_string(),
+            PropertyValue::Url { .. } => "Url".to_string(),
+            PropertyValue::Email { .. } => "Email".to_string(),
+            PropertyValue::PhoneNumber { .. } => "PhoneNumber".to_string(),
+            PropertyValue::Formula { .. } => "Formula".to_string(),
+            PropertyValue::Relation { .. } => "Relation".to_string(),
+            PropertyValue::Rollup { .. } => "Rollup".to_string(),
+            PropertyValue::CreatedTime { .. } => "CreatedTime".to_string(),
+            PropertyValue::CreatedBy { .. } => "CreatedBy".to_string(),
+            PropertyValue::LastEditedTime { .. } => "LastEditedTime".to_string(),
+            PropertyValue::LastEditedBy { .. } => "LastEditedBy".to_string(),
+            PropertyValue::Button { .. } => "Button".to_string(),
+        }
+    }
 }
 
 /// <https://developers.notion.com/reference/page#rollup-property-value-element>
@@ -567,4 +935,207 @@ pub enum RollupPropertyValue {
     LastEditedBy {
         last_edited_by: User,
     },
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
+pub struct WrongPropertyTypeError {
+    pub expected: Vec<String>,
+    pub actual: String,
+}
+
+impl Display for WrongPropertyTypeError {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(
+            f,
+            "Wrong property type: expected one of {:?}, got {}",
+            self.expected, self.actual
+        )
+    }
+}
+
+pub trait FromPropertyValue: Sized {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError>;
+}
+
+impl FromPropertyValue for Vec<RichText> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Title { title, .. } => Ok(title),
+            PropertyValue::Text { rich_text, .. } => Ok(rich_text),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Title".to_string(), "Text".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<Number> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Number { number, .. } => Ok(number),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Number".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<SelectedValue> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Select { select, .. } => Ok(select),
+            PropertyValue::Status { status, .. } => Ok(status),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Select".to_string(), "Status".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<Vec<SelectedValue>> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::MultiSelect { multi_select, .. } => Ok(multi_select),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["MultiSelect".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<DateValue> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Date { date, .. } => Ok(date),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Date".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for FormulaResultValue {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Formula { formula, .. } => Ok(formula),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Formula".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<Vec<RelationValue>> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Relation { relation, .. } => Ok(relation),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Relation".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<Vec<FileReference>> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Files { files, .. } => Ok(files),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Files".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for bool {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Checkbox { checkbox, .. } => Ok(checkbox),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Checkbox".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<String> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Url { url, .. } => Ok(url),
+            PropertyValue::Email { email, .. } => Ok(email),
+            PropertyValue::PhoneNumber { phone_number, .. } => Ok(phone_number),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec![
+                    "Url".to_string(),
+                    "Email".to_string(),
+                    "PhoneNumber".to_string(),
+                ],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for DateTime<Utc> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::CreatedTime { created_time, .. } => Ok(created_time),
+            PropertyValue::LastEditedTime {
+                last_edited_time, ..
+            } => Ok(last_edited_time),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["CreatedTime".to_string(), "LastEditedTime".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for User {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::CreatedBy { created_by, .. } => Ok(created_by),
+            PropertyValue::LastEditedBy { last_edited_by, .. } => Ok(last_edited_by),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["CreatedBy".to_string(), "LastEditedBy".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<Vec<User>> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::People { people, .. } => Ok(Some(people)),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["People".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
+}
+
+impl FromPropertyValue for Option<RollupValue> {
+    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
+        match value {
+            PropertyValue::Rollup { rollup, .. } => Ok(rollup),
+            _ => Err(WrongPropertyTypeError {
+                expected: vec!["Rollup".to_string()],
+                actual: value.type_name(),
+            }),
+        }
+    }
 }

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -502,7 +502,7 @@ impl PropertyValue {
     ///
     /// This is useful if you know the type of the property you want to access and don't need match statements
     ///
-    /// ```rust,ignore
+    /// ```ignore
     /// let title = property.expect_value::<Vec<RichText>>().unwrap();
     /// ```
     /// This will fail if the actual property type is not compatible with the expected value type.
@@ -525,7 +525,7 @@ impl PropertyValue {
     ///
     /// For example if you want to access text property values always as a `String` without formatting you can do the following:
     ///
-    /// ```rust
+    /// ```ignore
     /// use rusticnotion::models::properties::{FromPropertyValue, PropertyValue, WrongPropertyTypeError}
     ///
     /// // We can use the new type pattern to create a custom type that implements FromPropertyValue

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -260,6 +260,33 @@ pub enum PropertyConfiguration {
         id: PropertyId,
     },
 }
+impl PropertyConfiguration {
+    pub fn id(&self) -> &PropertyId {
+        match self {
+            PropertyConfiguration::Title { id } => id,
+            PropertyConfiguration::Text { id } => id,
+            PropertyConfiguration::Number { id, .. } => id,
+            PropertyConfiguration::Select { id, .. } => id,
+            PropertyConfiguration::Status { id, .. } => id,
+            PropertyConfiguration::MultiSelect { id, .. } => id,
+            PropertyConfiguration::Date { id } => id,
+            PropertyConfiguration::People { id } => id,
+            PropertyConfiguration::Files { id } => id,
+            PropertyConfiguration::Checkbox { id } => id,
+            PropertyConfiguration::Url { id } => id,
+            PropertyConfiguration::Email { id } => id,
+            PropertyConfiguration::PhoneNumber { id } => id,
+            PropertyConfiguration::Formula { id, .. } => id,
+            PropertyConfiguration::Relation { id, .. } => id,
+            PropertyConfiguration::Rollup { id, .. } => id,
+            PropertyConfiguration::CreatedTime { id } => id,
+            PropertyConfiguration::CreatedBy { id } => id,
+            PropertyConfiguration::LastEditedTime { id } => id,
+            PropertyConfiguration::LastEditBy { id } => id,
+            PropertyConfiguration::Button { id } => id,
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct SelectedValue {
@@ -441,6 +468,33 @@ pub enum PropertyValue {
     Button {
         id: PropertyId,
     },
+}
+impl PropertyValue {
+    pub fn id(&self) -> &PropertyId {
+        match self {
+            PropertyValue::Title { id, .. } => id,
+            PropertyValue::Text { id, .. } => id,
+            PropertyValue::Number { id, .. } => id,
+            PropertyValue::Select { id, .. } => id,
+            PropertyValue::Status { id, .. } => id,
+            PropertyValue::MultiSelect { id, .. } => id,
+            PropertyValue::Date { id, .. } => id,
+            PropertyValue::People { id, .. } => id,
+            PropertyValue::Files { id, .. } => id,
+            PropertyValue::Checkbox { id, .. } => id,
+            PropertyValue::Url { id, .. } => id,
+            PropertyValue::Email { id, .. } => id,
+            PropertyValue::PhoneNumber { id, .. } => id,
+            PropertyValue::Formula { id, .. } => id,
+            PropertyValue::Relation { id, .. } => id,
+            PropertyValue::Rollup { id, .. } => id,
+            PropertyValue::CreatedTime { id, .. } => id,
+            PropertyValue::CreatedBy { id, .. } => id,
+            PropertyValue::LastEditedTime { id, .. } => id,
+            PropertyValue::LastEditedBy { id, .. } => id,
+            PropertyValue::Button { id } => id,
+        }
+    }
 }
 
 /// <https://developers.notion.com/reference/page#rollup-property-value-element>


### PR DESCRIPTION
This is kind of a bigger one.  
I always found it pretty annoying to access a property value and hard to debug when you got something wrong. It wasn't possible to access a property by ID.  
So this first of all adds `get_by_name` and `get_by_id` to the `Properties` struct.  

To make it easier to access the values of a property in cases where you know the property type or expect a specific property type, this adds the `FromPropertyValue` trait and a bunch of convenience methods.  

The trait also allows the user to define a specific type in which they want to receive the value of a property.  

For easy access to the boolean state of a checkbox property, the following boilerplate was necessary, and you still had annoying error handling.  
```rust
let is_active = match page.properties.properties.get("active").unwrap() {
     PropertyValue::Checkbox { checkbox, .. } => Ok(checkbox),
      _ => Err("Wrong property type"), // What property types is it instead???
};
```  

The above code can now be done as follows:  

```rust
let is_active = page
    .properties
    .get_by_name("active")
    .unwrap() // None if property is missing
    .expect_checkbox() // or `.expect_value::<bool>()` if not explicit about the property type
    .unwrap() // Helpful error message with expected and actual types
```  

Example using the trait for a custom type:  

```rust
// We can use the new type pattern to create a custom type that implements FromPropertyValue
// This allows us easy access to property value in our desired type
struct TextValue(String);
impl FromPropertyValue for TextValue {
    fn from_property_value(value: PropertyValue) -> Result<Self, WrongPropertyTypeError> {
        match value {
            PropertyValue::Text { rich_text, .. } => {
                let combined_text = rich_text
                    .iter()
                    .map(|rt| rt.plain_text().to_string())
                    .collect::<Vec<String>>()
                    .join("");
                Ok(TextValue(combined_text))
            }
            _ => Err(WrongPropertyTypeError {
                expected: vec!["Text".to_string()],
                actual: value.type_name(),
            }),
        }
    }
}

assert_eq!(
    page.properties
        .get_by_name("Text")
        .unwrap()
        .expect_value::<TextValue>()
        .unwrap()
        .0,
    "hello world".to_string()
);
```  

I've found this very useful in my application where I have to access a lot of properties. But it is, of course, a larger addition. Let me know what you think.